### PR TITLE
Relocate Guava classes and minimize Jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .idea
 *.iml
+dependency-reduced-pom.xml

--- a/jax-rs-linker/pom.xml
+++ b/jax-rs-linker/pom.xml
@@ -82,6 +82,38 @@
                     </annotationProcessors>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <artifactSet>
+                        <includes>
+                            <include>com.google.guava:guava</include>
+                        </includes>
+                    </artifactSet>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google</pattern>
+                            <shadedPattern>hidden.com.google</shadedPattern>
+                            <excludes>
+                                <exclude>com.google.common.base.Optional</exclude>
+                                <exclude>com.google.common.base.Present</exclude>
+                                <exclude>com.google.common.base.Absent</exclude>
+                            </excludes>
+                        </relocation>
+                    </relocations>
+                    <minimizeJar>true</minimizeJar>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
C'est pas optimal pour le moment.
J'ai un soucis avec Optional, si je le relocalise comme les autres, le build multi module échoue.
Le module d'intégration ne compile pas car il ne trouve pas Optional dans le package hidden.com.google.common

Si tu peux tester de ton côté @fbiville

Pour l'instant je garde Optional et ses dépendances sans les déplacer.

Sinon le minimize permer de passer de 2,2M à 924K.