### PR TITLE
Issue #31. Remove state from Annotation Processor

### DIFF
--- a/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/ExposedApplicationAnnotationProcessor.java
+++ b/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/ExposedApplicationAnnotationProcessor.java
@@ -1,0 +1,88 @@
+package fr.vidal.oss.jax_rs_linker;
+
+import com.google.auto.service.AutoService;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import fr.vidal.oss.jax_rs_linker.api.ExposedApplication;
+import fr.vidal.oss.jax_rs_linker.errors.CompilationError;
+import fr.vidal.oss.jax_rs_linker.visitor.ApplicationNameVisitor;
+import fr.vidal.oss.jax_rs_linker.writer.ApplicationNameWriter;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import java.io.IOException;
+import java.util.Set;
+
+import static com.google.common.base.Optional.absent;
+import static com.google.common.base.Throwables.propagate;
+import static com.google.common.collect.Sets.newHashSet;
+import static javax.lang.model.SourceVersion.latest;
+import static javax.tools.Diagnostic.Kind.ERROR;
+
+@AutoService(Processor.class)
+public class ExposedApplicationAnnotationProcessor extends AbstractProcessor {
+
+    private Messager messager;
+    private Filer filer;
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return newHashSet(ExposedApplication.class.getName());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return latest();
+    }
+
+    @Override
+    public void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        messager = processingEnv.getMessager();
+        filer = processingEnv.getFiler();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        Optional<? extends TypeElement> maybeExposedApplication = extractExposedApplication(annotations);
+        if (maybeExposedApplication.isPresent()) {
+            Optional<String> name = parseApplicationName(roundEnv);
+            if (!name.isPresent()) {
+                return false;
+            }
+            write(name.get());
+        }
+
+        return false;
+    }
+
+    private void write(String name) {
+        try {
+            new ApplicationNameWriter(filer).write(name);
+        } catch (IOException e) {
+            throw propagate(e);
+        }
+    }
+
+    private Optional<String> parseApplicationName(RoundEnvironment roundEnv) {
+        Set<? extends Element> applications = roundEnv.getElementsAnnotatedWith(ExposedApplication.class);
+        if (applications.size() != 1) {
+            messager.printMessage(ERROR, CompilationError.ONE_APPLICATION_ONLY.text());
+            return absent();
+        }
+        return new ApplicationNameVisitor(messager).visit(applications.iterator().next());
+    }
+
+    private Optional<? extends TypeElement> extractExposedApplication(Set<? extends TypeElement> annotations) {
+        return FluentIterable.from(annotations)
+            .firstMatch(new Predicate<TypeElement>() {
+                @Override
+                public boolean apply(TypeElement typeElement) {
+                    return typeElement.getQualifiedName().contentEquals(ExposedApplication.class.getCanonicalName());
+                }
+            });
+    }
+}

--- a/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/errors/CompilationError.java
+++ b/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/errors/CompilationError.java
@@ -34,9 +34,6 @@ public enum CompilationError {
         "\n\tEither annotate your configuration class with @ApplicationPath or provide a servletName to @ExposedApplication (not both)." +
         "\n\tGiven class: <%s>"
     ),
-    NO_APPLICATION_FOUND(
-        "\n\tThere should be exactly one @ExposedApplication-annotated Jersey Application: none found."
-    ),
     NO_APPLICATION_SERVLET_NAME(
         "\n\t@ExposedApplication servletName must not be empty when used on a package." +
         "\n\tGiven package: <%s>"

--- a/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/writer/ApplicationNameWriter.java
+++ b/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/writer/ApplicationNameWriter.java
@@ -1,0 +1,37 @@
+package fr.vidal.oss.jax_rs_linker.writer;
+
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.TypeSpec;
+
+import javax.annotation.processing.Filer;
+import java.io.IOException;
+
+import static com.squareup.javapoet.MethodSpec.methodBuilder;
+import static com.squareup.javapoet.TypeSpec.classBuilder;
+import static javax.lang.model.element.Modifier.*;
+
+public class ApplicationNameWriter {
+
+    private final Filer filer;
+
+    public ApplicationNameWriter(Filer filer) {
+        this.filer = filer;
+    }
+
+    public void write(String name) throws IOException {
+
+        TypeSpec type = classBuilder("ApplicationName")
+            .addModifiers(PUBLIC, FINAL)
+            .addMethod(methodBuilder("get")
+                .returns(String.class)
+                .addModifiers(PUBLIC, STATIC)
+                .addStatement("return $S", name)
+                .build())
+            .build();
+
+        JavaFile.builder("fr.vidal.oss.jax_rs_linker", type)
+            .indent("\t")
+            .build()
+            .writeTo(filer);
+    }
+}

--- a/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/writer/LinkersWriter.java
+++ b/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/writer/LinkersWriter.java
@@ -14,6 +14,7 @@ import java.beans.Introspector;
 import java.io.IOException;
 import java.util.Set;
 
+import static com.squareup.javapoet.ClassName.get;
 import static javax.lang.model.element.Modifier.*;
 
 public class LinkersWriter {
@@ -24,7 +25,7 @@ public class LinkersWriter {
         this.filer = filer;
     }
 
-    public void write(ClassName linkers, Set<ClassName> classes, String applicationName) throws IOException {
+    public void write(ClassName linkers, Set<ClassName> classes) throws IOException {
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(linkers.className())
             .addModifiers(PUBLIC, FINAL)
             .addSuperinterface(ServletContextListener.class)
@@ -37,7 +38,7 @@ public class LinkersWriter {
                 .initializer("\"\"")
                 .build())
             .addField(FieldSpec.builder(String.class, "applicationName", PRIVATE, STATIC)
-                .initializer("$S", applicationName)
+                .initializer("$T.get()", get("fr.vidal.oss.jax_rs_linker", "ApplicationName"))
                 .build())
             .addMethod(MethodSpec.methodBuilder("contextInitialized")
                 .addModifiers(PUBLIC)

--- a/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/ExposedApplicationAnnotationProcessorTest.java
+++ b/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/ExposedApplicationAnnotationProcessorTest.java
@@ -1,0 +1,30 @@
+package fr.vidal.oss.jax_rs_linker;
+
+import com.google.common.collect.ImmutableList;
+import com.google.testing.compile.CompilationRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assert_;
+import static com.google.testing.compile.JavaFileObjects.forResource;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+public class ExposedApplicationAnnotationProcessorTest {
+
+    @Rule
+    public CompilationRule compilation = new CompilationRule();
+    private ExposedApplicationAnnotationProcessor processor = new ExposedApplicationAnnotationProcessor();
+
+
+    @Test
+    public void generates_application_name_enum() {
+        assert_().about(javaSource())
+            .that(forResource("Configuration.java"))
+            .processedWith(processor)
+            .compilesWithoutError()
+            .and()
+            .generatesSources(forResource("ApplicationName.java"));
+
+
+    }
+}

--- a/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/LinkerAnnotationProcessorTest.java
+++ b/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/LinkerAnnotationProcessorTest.java
@@ -18,6 +18,7 @@ public class LinkerAnnotationProcessorTest {
     public CompilationRule compilation = new CompilationRule();
 
     private LinkerAnnotationProcessor processor = new LinkerAnnotationProcessor();
+    private ExposedApplicationAnnotationProcessor applicationNameProcessor = new ExposedApplicationAnnotationProcessor();
 
     @Test
     public void generates_graph_of_linkers() {
@@ -28,7 +29,7 @@ public class LinkerAnnotationProcessorTest {
                 forResource("BrandResource.java"),
                 forResource("PersonResource.java")
             ))
-            .processedWith(processor)
+            .processedWith(processor, applicationNameProcessor)
             .compilesWithoutError()
             .and()
             .generatesSources(
@@ -49,7 +50,7 @@ public class LinkerAnnotationProcessorTest {
                         forResource("Configuration.java"),
                         forResource("DevNullResource.java")
                 ))
-                .processedWith(processor)
+                .processedWith(processor, applicationNameProcessor)
                 .compilesWithoutError()
                 .and()
                 .generatesSources(
@@ -76,7 +77,7 @@ public class LinkerAnnotationProcessorTest {
     public void fails_to_generate_linkers_if_too_many_self_annotations_on_1_resource() {
         assert_().about(javaSource())
                 .that(forResource("SelfObsessedResource.java"))
-                .processedWith(processor)
+                .processedWith(processor, applicationNameProcessor)
                 .failsToCompile()
                 .withErrorContaining(
                         "\n  \tThe enclosing class already defined one @Self-annotated method. Only one method should be annotated so." +
@@ -91,7 +92,7 @@ public class LinkerAnnotationProcessorTest {
                         forResource("GalleryResource.java"),
                         forResource("SelfObsessedResource.java")
                 ))
-                .processedWith(processor)
+                .processedWith(processor, applicationNameProcessor)
                 .failsToCompile()
                 .withErrorContaining(
                         "\n  \tThe enclosing class already defined one @Self-annotated method. Only one method should be annotated so." +
@@ -105,7 +106,7 @@ public class LinkerAnnotationProcessorTest {
 
         assert_().about(javaSource())
             .that(configuration)
-            .processedWith(processor)
+            .processedWith(processor, applicationNameProcessor)
             .failsToCompile()
             .withErrorContaining(
                 "\n  \tEither annotate your configuration class with @ApplicationPath or provide a servletName to @ExposedApplication (not both)." +
@@ -121,12 +122,13 @@ public class LinkerAnnotationProcessorTest {
                 forResource("package-info.java"),
                 forResource("BrandResource.java")
             ))
-            .processedWith(processor)
+            .processedWith(processor, applicationNameProcessor)
             .compilesWithoutError()
             .and()
             .generatesSources(
                 forResource("BrandResourceLinker.java"),
-                forResource("linkers/LinkersPackageInfo.java")
+                forResource("linkers/LinkersPackageInfo.java"),
+                forResource("linkers/ApplicationNamePackageInfo.java")
             );
     }
 
@@ -136,7 +138,7 @@ public class LinkerAnnotationProcessorTest {
 
         assert_().about(javaSource())
             .that(configuration)
-            .processedWith(processor)
+            .processedWith(processor, applicationNameProcessor)
             .failsToCompile()
             .withErrorContaining(
                 "\n  \t@ExposedApplication servletName must not be empty when used on a package." +

--- a/jax-rs-linker/src/test/resources/ApplicationName.java
+++ b/jax-rs-linker/src/test/resources/ApplicationName.java
@@ -1,0 +1,9 @@
+package fr.vidal.oss.jax_rs_linker;
+
+import java.lang.String;
+
+public final class ApplicationName {
+	public static String get() {
+		return "fr.vidal.oss.jax_rs_linker.it.Configuration";
+	}
+}

--- a/jax-rs-linker/src/test/resources/linkers/ApplicationNamePackageInfo.java
+++ b/jax-rs-linker/src/test/resources/linkers/ApplicationNamePackageInfo.java
@@ -1,0 +1,9 @@
+package fr.vidal.oss.jax_rs_linker;
+
+import java.lang.String;
+
+public final class ApplicationName {
+	public static String get() {
+		return "my-super-application";
+	}
+}

--- a/jax-rs-linker/src/test/resources/linkers/Linkers.java
+++ b/jax-rs-linker/src/test/resources/linkers/Linkers.java
@@ -17,7 +17,7 @@ import javax.servlet.annotation.WebListener;
 public final class Linkers implements ServletContextListener {
     private static String contextPath = "";
 
-    private static String applicationName = "fr.vidal.oss.jax_rs_linker.it.Configuration";
+    private static String applicationName = ApplicationName.get();
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {

--- a/jax-rs-linker/src/test/resources/linkers/LinkersPackageInfo.java
+++ b/jax-rs-linker/src/test/resources/linkers/LinkersPackageInfo.java
@@ -15,7 +15,7 @@ import javax.servlet.annotation.WebListener;
 public final class Linkers implements ServletContextListener {
     private static String contextPath = "";
 
-    private static String applicationName = "my-super-application";
+    private static String applicationName = ApplicationName.get();
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {


### PR DESCRIPTION
IDEA incremental compilation triggered false compilation errors,
most likely because `@ExposedApplication`-annotated elements are
not processed again, thus resulting in `LinkerAnnotationProcessor`
stale state.

This fix consists in generating a Java class holding the
application name.

If `@ExposedApplication` is missing, this will result in a
compiler error (in `Linkers`).