### PR TITLE
Handle query parameters via their annotation name

### DIFF
--- a/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/functions/VariableElementToQueryParameter.java
+++ b/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/functions/VariableElementToQueryParameter.java
@@ -6,6 +6,7 @@ import fr.vidal.oss.jax_rs_linker.model.QueryParameter;
 
 import javax.annotation.Nullable;
 import javax.lang.model.element.VariableElement;
+import javax.ws.rs.QueryParam;
 
 public enum VariableElementToQueryParameter implements Function<VariableElement, QueryParameter>{
 
@@ -13,8 +14,10 @@ public enum VariableElementToQueryParameter implements Function<VariableElement,
 
     @Nullable
     @Override
-    public QueryParameter apply(VariableElement input) {
-        return new QueryParameter(ClassName.valueOf(input.getEnclosingElement().getEnclosingElement().getSimpleName().toString()), input.getSimpleName().toString());
+    public QueryParameter apply(VariableElement parameterElement) {
+        return new QueryParameter(
+            ClassName.valueOf(parameterElement.getEnclosingElement().getEnclosingElement().getSimpleName().toString()),
+            parameterElement.getAnnotation(QueryParam.class).value());
     }
 
 }

--- a/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/writer/EnumConstants.java
+++ b/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/writer/EnumConstants.java
@@ -6,6 +6,9 @@ import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 public class EnumConstants {
 
     public static String constantName(String name) {
-        return UPPER_CAMEL.to(UPPER_UNDERSCORE, name);
+        return UPPER_CAMEL
+            .to(UPPER_UNDERSCORE, name)
+            .replace(' ', '_')
+            .replace('-', '_');
     }
 }

--- a/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/parser/PagingTest.java
+++ b/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/parser/PagingTest.java
@@ -1,0 +1,16 @@
+package fr.vidal.oss.jax_rs_linker.parser;
+
+import javax.ws.rs.*;
+
+public class PagingTest {
+    private final int pageStart;
+    private final int pageSize;
+
+    public PagingTest(@DefaultValue("1") @QueryParam("start-page") int pageStart,
+                      @DefaultValue("25") @QueryParam("page-size") int pageSize) {
+
+        this.pageStart = pageStart;
+        this.pageSize = pageSize;
+    }
+
+}

--- a/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/writer/EnumConstantsTest.java
+++ b/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/writer/EnumConstantsTest.java
@@ -1,0 +1,7 @@
+package fr.vidal.oss.jax_rs_linker.writer;
+
+import static org.junit.Assert.*;
+
+public class EnumConstantsTest {
+
+}

--- a/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/writer/EnumConstantsTest.java
+++ b/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/writer/EnumConstantsTest.java
@@ -1,7 +1,21 @@
 package fr.vidal.oss.jax_rs_linker.writer;
 
-import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class EnumConstantsTest {
 
+    @Test
+    public void should_generate_enum_compatible_names() {
+        assertThat(EnumConstants.constantName("camelCaseName")).isEqualTo("CAMEL_CASE_NAME");
+        assertThat(EnumConstants.constantName("space name")).isEqualTo("SPACE_NAME");
+        assertThat(EnumConstants.constantName("lowercase")).isEqualTo("LOWERCASE");
+    }
+
+    @Test
+    public void cannot_handle_only_uppercase_form() {
+        assertThat(EnumConstants.constantName("SPACE-COWBOY")).isNotEqualTo("SPACE_COWBOY");
+    }
 }

--- a/jax-rs-linker/src/test/resources/PersonResource.java
+++ b/jax-rs-linker/src/test/resources/PersonResource.java
@@ -14,7 +14,7 @@ public class PersonResource {
     @Self
     @Path("/{id}")
     @GET
-    public void getById(@PathParam("id") int id, @QueryParam("alive") boolean alive) {
+    public void getById(@PathParam("id") int id, @QueryParam("alive-flag") boolean alive) {
 
     }
 

--- a/jax-rs-linker/src/test/resources/PersonResourceQueryParameters.java
+++ b/jax-rs-linker/src/test/resources/PersonResourceQueryParameters.java
@@ -6,7 +6,7 @@ import javax.annotation.Generated;
 
 @Generated("fr.vidal.oss.jax_rs_linker.LinkerAnnotationProcessor")
 public enum PersonResourceQueryParameters implements QueryParameters {
-    ALIVE("alive");
+    ALIVE_FLAG("alive-flag");
 
     private final String value;
 


### PR DESCRIPTION
We used to use the parameter name instead of the annotated value
as name when generating our enum for Query parameters.
This is problematic when we're going to handle bean params as annotated arguments
may be on constructors (therefor will have a very bad name : arg0, etc.).
So instead of using the argument name, let's use the jersey annotation value as name.