### PR TITLE
Do not double slash when context path is root

### DIFF
--- a/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/servlet/ContextPaths.java
+++ b/jax-rs-linker/src/main/java/fr/vidal/oss/jax_rs_linker/servlet/ContextPaths.java
@@ -7,7 +7,12 @@ public class ContextPaths {
 
     public static String contextPath(ServletContext servletContext, String registeredKey) {
         String mappedPath = readMappingOrDefault(servletContext, registeredKey);
-        return servletContext.getContextPath() + mappedPath;
+        return trimSingleSlashContextPath(servletContext) + mappedPath;
+    }
+
+    private static String trimSingleSlashContextPath(ServletContext servletContext) {
+        String contextPath = servletContext.getContextPath();
+        return "/".equals(contextPath) ? "" : contextPath;
     }
 
     /**

--- a/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/servlet/ContextPathsTest.java
+++ b/jax-rs-linker/src/test/java/fr/vidal/oss/jax_rs_linker/servlet/ContextPathsTest.java
@@ -60,6 +60,17 @@ public class ContextPathsTest {
         assertThat(contextPath(servletContext, "w00t")).isEqualTo("/prefix/kikoo");
     }
 
+    @Test
+    public void no_double_slash_when_context_path_is_slash() {
+        ServletContext servletContext = servletContext(
+            servletRegistration(asList("/what")),
+            "w00t",
+            "/"
+        );
+
+        assertThat(contextPath(servletContext, "w00t")).isEqualTo("/what");
+    }
+
     private ServletContext servletContext(ServletRegistration servletRegistration, String applicationName, String contextPath) {
         ServletContext servletContext = mock(ServletContext.class);
         when(servletContext.getServletRegistration(applicationName)).thenReturn(servletRegistration);


### PR DESCRIPTION
At least with Tomcat (not reproduced with Jetty), ServletContext#getContextPath
returns '/'. When Jersey servlet is mapped on '/something', we ends by creating links
starting with '//something' which is wrong...